### PR TITLE
Fix get_session with mod_admin_shell

### DIFF
--- a/forkshell.lua
+++ b/forkshell.lua
@@ -13,13 +13,13 @@ local function get_session()
 		local info = debug.getinfo(i);
 		if not info then return nil; end
 
-		if info.name == "process_line" and info.source:match("mod_admin_telnet%.lua$") then
+		if info.name == nil and info.source:match("events%.lua$") then
 			for j=1,100 do
 				local key, val = debug.getlocal(i, j);
 				if not key then return nil; end
 
-				if key == "session" then
-					return val;
+				if key == "event_data" then
+					return val.origin;
 				end
 			end
 		end


### PR DESCRIPTION
After prosody refactored mod_admin_telnet into mod_admin_shell, it wasn't possible any more to obtain the session variable from the shell stack:

```
| /.../forkshell/forkshell.lua:158: attempt to index local 'session' (a nil value)
```

This PR instead fetches the session from the event's event_data.origin object.